### PR TITLE
 luci-app-https-dns-proxy: add multiple DNS providers

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.adblock.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.adblock.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "BlahDNS-Adblock",
+	label = _("BlahDNS Adblock"),
+	resolver_url = "https://doh1.blahdns.com/dns-query",
+	bootstrap_dns = "95.217.37.33",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS Support"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "BlahDNS",
+	label = _("BlahDNS"),
+	resolver_url = "https://doh-fi.blahdns.com/dns-query",
+	bootstrap_dns = "95.216.212.177,2a01:4f9:c010:43ce::1",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS Support"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.uncensored.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blah.uncensored.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "BlahDNS-Uncensored",
+	label = _("BlahDNS Uncensored"),
+	resolver_url = "https://doh1.blahdns.com/uncensor",
+	bootstrap_dns = "95.217.37.33",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS Support"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.power.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.power.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "PowerDNS",
+	label = _("PowerDNS"),
+	resolver_url = " https://doh.powerdns.org/",
+	bootstrap_dns = "136.144.215.158,2a01:7c8:d002:1ef:5054:ff:fe40:3703",
+	help_link = "https://powerdns.org/",
+	help_link_text = "PowerDNS"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.snopyta.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.snopyta.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "Snopyta",
+	label = _("Snopyta"),
+	resolver_url = "https://fi.doh.dns.snopyta.org/dns-query",
+	bootstrap_dns = "95.216.229.153,2a01:4f9:2a:1919::21",
+	help_link = "https://snopyta.org/index.html#faq",
+	help_link_text = "Snopyta"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.uncensoreddns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.uncensoreddns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "UncensoredDNS",
+	label = _("UncensoredDNS"),
+	resolver_url = "https://anycast.uncensoreddns.org/dns-query",
+	bootstrap_dns = "91.239.100.100",
+	help_link = "https://blog.uncensoreddns.org/dns-servers/",
+	help_link_text = "UncensoredDNS"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/services.nixnet.adblock.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/services.nixnet.adblock.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "NixNet-Adblock",
+	label = _("NixNet Adblock"),
+	resolver_url = "https://adblock.any.dns.nixnet.xyz/dns-query",
+	bootstrap_dns = "198.251.90.89",
+	help_link = "https://docs.nixnet.services/NixNet_DNS",
+	help_link_text = "NixNet DNS Support"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/services.nixnet.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/services.nixnet.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "NixNet",
+	label = _("NixNet"),
+	resolver_url = "https://uncensored.any.dns.nixnet.xyz/dns-query",
+	bootstrap_dns = "198.251.90.91",
+	help_link = "https://docs.nixnet.services/NixNet_DNS",
+	help_link_text = "NixNet DNS Support"
+}


### PR DESCRIPTION
Add multiple no-log DNS providers based on the useful PrivacyTools.IO DNS page (https://privacytools.io/providers/dns/): 
- BlahDNS 
- PowerDNS 
- NixNet 
- Snopyta
- UncensoredDNS

My first ever commit/pull-request to a public repository so please be kind. :) Signed-off-by: Jordy Kuijt github@kuijt.eu